### PR TITLE
Add validate-no-utf8mb4-characters

### DIFF
--- a/view/frontend/web/js/components/validators/core.js
+++ b/view/frontend/web/js/components/validators/core.js
@@ -68,13 +68,8 @@
         'validate-no-utf8mb4-characters': [
             (value) => !/(?:[\uD800-\uDBFF][\uDC00-\uDFFF])/g.test(value),
             (value) => {
-                var message = $t('Please remove invalid characters: {0}.'),
-                    matches = value.match(/(?:[\uD800-\uDBFF][\uDC00-\uDFFF])/g),
-                    result = matches === null;
-                if (!result) {
-                    message = message.replace('{0}', matches.join());
-                }
-                return message;
+                var matches = value.match(/(?:[\uD800-\uDBFF][\uDC00-\uDFFF])/g);
+                return $t('Please remove invalid characters: {0}.').replace('{0}', matches.join());
             }
         ],
     });

--- a/view/frontend/web/js/components/validators/core.js
+++ b/view/frontend/web/js/components/validators/core.js
@@ -65,6 +65,18 @@
             },
             $t('Please select one of the options.')
         ],
+        'validate-no-utf8mb4-characters': [
+            (value) => !/(?:[\uD800-\uDBFF][\uDC00-\uDFFF])/g.test(value),
+            (value) => {
+                var message = $t('Please remove invalid characters: {0}.'),
+                    matches = value.match(/(?:[\uD800-\uDBFF][\uDC00-\uDFFF])/g),
+                    result = matches === null;
+                if (!result) {
+                    message = message.replace('{0}', matches.join());
+                }
+                return message;
+            }
+        ],
     });
 
     // Validate Date


### PR DESCRIPTION
Magento 2 validation rule reference: 

https://github.com/magento/magento2/blob/1475eb2fb6eab1aa72482c50ee119f5eb01fafb6/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js#L1099

Example:

<img width="383" alt="image" src="https://github.com/breezefront/module-breeze/assets/4760084/5719ce34-47ff-417e-8216-19bb360ff066">

