### PR TITLE
Wait for DOM to be ready before looking for elements

### DIFF
--- a/view/frontend/templates/theme/scroll-reveal.phtml
+++ b/view/frontend/templates/theme/scroll-reveal.phtml
@@ -17,7 +17,7 @@
 }
 </style>
 <script>
-require(['jquery', 'underscore'], ($, _) => {
+require(['jquery', 'underscore', 'domReady!'], ($, _) => {
     var selector = <?= $block->getJsSelector() ?>,
         containers = [
             '.scroll-reveal-cascade',


### PR DESCRIPTION
Currently there can be a race condition, especially with certain (3rd party) pagebuilders where the scroll reveal tries to apply to the elements before they've loaded in the dom, thereby leaving them as invisible.

Waiting for the dom to be ready seems sensible to avoid issues.