### PR TITLE
Minor W3C validation fix in Preload.php

### DIFF
--- a/Block/Preload.php
+++ b/Block/Preload.php
@@ -31,7 +31,7 @@ class Preload extends \Magento\Framework\View\Element\AbstractBlock
             }
             $renderedAttributes = join(' ', $renderedAttributes);
 
-            $items[$renderedAttributes] = '<link rel="preload" fetchpriority="high" ' . $renderedAttributes . '/>';
+            $items[$renderedAttributes] = '<link rel="preload" fetchpriority="high" ' . $renderedAttributes . '>';
         }
 
         return implode("\n", $items);


### PR DESCRIPTION
Unnecessary trailing / gives W3C Validation "info" level notification:

`Info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.`