### PR TITLE
Allow configuring scroll reveal onReveal options

### DIFF
--- a/Block/Theme/ScrollReveal.php
+++ b/Block/Theme/ScrollReveal.php
@@ -54,4 +54,20 @@ class ScrollReveal extends Template
     {
         return $this->json->serialize(implode(',', $this->getSelectors()));
     }
+
+    /**
+     * Get options for on reveal event
+     *
+     * @return string
+     */
+    public function getOnRevealOptions(): string
+    {
+        $options = $this->getData('on_reveal_options');
+
+        if (!is_array($options)) {
+            $options = [];
+        }
+
+        return $this->json->serialize($options);
+    }
 }

--- a/view/frontend/templates/theme/scroll-reveal.phtml
+++ b/view/frontend/templates/theme/scroll-reveal.phtml
@@ -9,6 +9,7 @@
 <script>
 require(['jquery', 'underscore'], ($, _) => {
     var selector = <?= /* @noEscape */ $block->getJsSelector() ?>,
+        revealOptions = <?= /* @noEscape */ $block->getOnRevealOptions() ?>,
         containers = [
             '.scroll-reveal-cascade',
             '.scroll-reveal-container',
@@ -38,7 +39,7 @@ require(['jquery', 'underscore'], ($, _) => {
                 .one('animationend', function () {
                     $(this).addClass('scroll-reveal-finished');
                 });
-        });
+        }, revealOptions);
     }, 40));
 });
 </script>


### PR DESCRIPTION
Add support for passing onReveal options as the second argument in scroll-reveal.phtml.

**Description**
This allows customizing IntersectionObserver behavior (for example, rootMargin: '-20px') via layout XML or plugins without changing template logic.

**Changes**
Added getOnRevealOptions() to ScrollReveal block.
Updated scroll-reveal.phtml to call:
.onReveal(callback, revealOptions)
Options are read only from on_reveal_options block data and safely default to {} when invalid/non-array.