### PR TITLE
Fix scope binding crash on virtual elements

### DIFF
--- a/view/frontend/web/js/core/extend-ko.js
+++ b/view/frontend/web/js/core/extend-ko.js
@@ -85,7 +85,7 @@ define(['ko/template/renderer'], (renderer) => {
     function applyComponents(el, bindingContext, promise, component) {
         promise.resolve();
 
-        if (component.index && el.nodeType === Node.ELEMENT_NODE && $(el).component(component.index)) {
+        if (component.index && !isVirtualElement(el) && $(el).component(component.index)) {
             return;
         }
 

--- a/view/frontend/web/js/core/extend-ko.js
+++ b/view/frontend/web/js/core/extend-ko.js
@@ -85,7 +85,7 @@ define(['ko/template/renderer'], (renderer) => {
     function applyComponents(el, bindingContext, promise, component) {
         promise.resolve();
 
-        if (component.index && $(el).component(component.index)) {
+        if (component.index && el.nodeType === Node.ELEMENT_NODE && $(el).component(component.index)) {
             return;
         }
 


### PR DESCRIPTION
## Problem

Since af420909 (released in 2.30.0), `applyComponents()` in `view/frontend/web/js/core/extend-ko.js` calls `$(el).component(component.index)` to skip already-mounted components. When the `scope` binding is used on a KO virtual element (`<!-- ko scope: ... -->`), `el` is a comment node. The call falls through Breeze's `$.fn.data` wrapper into cash's native `data()`, which reads `node.dataset[...]` — comment nodes have no `dataset`, so it throws:

```
TypeError: Cannot read properties of undefined (reading 'component:knowledge-base-listing_categories_list')
```

The exception aborts the whole descendant render. Visible fallout: Swissup_KnowledgeBase listing pages are blank on Breeze storefronts (swissup/module-knowledge-base#19, reproduced on argentotheme.com/knowledgebase and firecheckout.net/knowledge).

## Fix

Run the already-mounted check only for element nodes. Components are never stored on comment nodes, so the check is meaningless there and the previous (pre-af420909) behavior is restored for virtual elements.

## Testing

Reproduced the blank knowledge base page locally (Magento 2.4.8-p1, Swissup/argento-420shop theme). With this patch the listing renders fully (categories, articles, paging) with no console errors; verified the ReCaptcha-style already-mounted guard still applies to element nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)